### PR TITLE
fix: add missing function call

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ const parseArgs = () => ({
 
 const { branch, id } = parseArgs();
 
-const currentBranch = git.getCurrentBranch;
+const currentBranch = git.getCurrentBranch();
 
 git.checkout(branch);
 


### PR DESCRIPTION
There is a missing call to get current branch. Because of it git doesn't return back to the branch script was started at.